### PR TITLE
Add configurable timer-based auto-exit (#6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,56 @@
 version = 4
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21,12 +71,59 @@ dependencies = [
 name = "cat_shield"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "objc2",
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-core-graphics",
  "objc2-foundation",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "dispatch2"
@@ -37,6 +134,18 @@ dependencies = [
  "bitflags",
  "objc2",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "libc"
@@ -210,4 +319,72 @@ dependencies = [
  "bitflags",
  "objc2",
  "objc2-foundation",
+]
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9695f8df41bb4f3d222c95a67532365f569318332d03d5f3f67f37b20e6ebdf0"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "2.0.112"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21f182278bf2d2bcb3c88b1b08a37df029d71ce3d3ae26168e3c653b213b99d4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["macos", "utility", "screen-lock", "input-blocking"]
 categories = ["command-line-utilities"]
 
 [dependencies]
+clap = { version = "4.5", features = ["derive"] }
 objc2 = "0.6"
 objc2-foundation = "0.3"
 objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSBezierPath", "NSColor", "NSEvent", "NSScreen", "NSView", "NSWindow"] }

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,6 +29,12 @@ Cat Shield is a macOS utility that creates a semi-transparent overlay to block k
   - Visual progress ring indicator during hold
   - Works without Accessibility permissions
   - Provides reliable exit mechanism when keyboard shortcut not available
+- [x] **Issue #6**: Add configurable timer-based auto-exit
+  - CLI argument for timer duration: `--timer` / `-t` (supports minutes, hours, combined)
+  - Visual countdown progress bar on overlay (can be hidden with `--hide-timer`)
+  - Warning notification 1 minute before auto-exit
+  - Clean exit when timer expires
+  - Timer validation (1 minute minimum, 24 hours maximum)
 
 ## Open Issues
 
@@ -48,6 +54,11 @@ Potential future enhancements (not yet tracked as issues):
 ## Changelog
 
 ### 2025-12-31
+- Added configurable timer-based auto-exit (Issue #6)
+  - Use `--timer 30m` or `-t 2h` to set auto-exit duration
+  - Visual progress bar shows remaining time on overlay
+  - Warning shown 1 minute before auto-exit
+  - Duration range: 1 minute to 24 hours
 - Added click-and-hold close button in top-right corner (Issue #5)
   - 3-second hold requirement prevents accidental exits from cats
   - Visual progress ring indicator during hold


### PR DESCRIPTION
## Summary

- Implements issue #6: Allow users to configure a timer so the shield automatically deactivates after a set duration
- Useful for lunch breaks, meetings, or other timed away periods without needing to manually exit

## Changes

- Added `clap` for CLI argument parsing
- New CLI arguments: `--timer` / `-t` for duration (e.g., 30m, 2h, 1h30m) and `--hide-timer` to hide countdown display
- Visual countdown progress bar on overlay (top-left corner)
- Warning notification printed to console 1 minute before auto-exit
- Clean exit when timer expires
- Duration validation: minimum 1 minute, maximum 24 hours
- Updated ROADMAP.md to mark issue #6 as completed

## Usage Examples

```bash
cat_shield --timer 30m      # Exit after 30 minutes
cat_shield --timer 2h       # Exit after 2 hours
cat_shield -t 1h30m         # Exit after 1 hour 30 minutes
cat_shield -t 45m --hide-timer  # Timer without visual display
```

## Test plan

- [x] `cargo build --release` succeeds
- [x] `cargo test` - all 17 tests pass (including 10 new duration parsing/formatting tests)
- [x] `cargo clippy` - no warnings
- [x] `--help` displays timer options correctly
- [x] Invalid durations are rejected with helpful error messages
- [ ] Manual test: timer countdown display works on overlay
- [ ] Manual test: warning appears 1 minute before exit
- [ ] Manual test: app exits cleanly when timer expires

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Timer-based auto-exit feature with configurable duration via `--timer/-t` option
- Visual countdown timer displayed on overlay, hideable with `--hide-timer`
- Automatic 1-minute warning before application exit
- Support for flexible duration formats with validation between 1 minute and 24 hours

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->