### PR TITLE
config: limit Claude GitHub Action to only respond to @claude mentions (#25)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,24 +1,18 @@
 name: Claude Code Assistant
 
-# Trigger the workflow when @claude is mentioned in issues or pull requests
+# Only trigger when @claude is mentioned in issue or PR comments
 on:
   issue_comment:
     types: [created]
-  pull_request_review_comment:
-    types: [created]
-  pull_request_review:
-    types: [submitted]
-  issues:
-    types: [opened, assigned]
-  pull_request:
-    types: [opened, synchronize]
 
 concurrency:
-  group: claude-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
+  group: claude-${{ github.event.issue.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:
   claude-response:
+    # Only run when @claude is explicitly mentioned in the comment
+    if: contains(github.event.comment.body, '@claude')
     runs-on: ubuntu-latest
 
     # Required permissions for Claude to interact with your repository

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -44,6 +44,13 @@ Cat Shield is a macOS utility that creates a semi-transparent overlay to block k
   - CLI argument takes precedence over config file
   - Default remains Cmd+Option+U for backwards compatibility
 
+### Configuration Improvements
+- [x] **Issue #25**: Limit Claude GitHub Action to only respond to comments
+  - Removed triggers for `pull_request`, `issues`, `pull_request_review`, `pull_request_review_comment`
+  - Kept only `issue_comment` trigger (fires on both issue and PR comments)
+  - Added `if: contains(github.event.comment.body, '@claude')` condition
+  - Claude now only responds when explicitly mentioned with `@claude`
+
 ### Phase 4: Menu-Based Application Interface (In Progress)
 - [x] **Issue #14**: Create Menu Bar Infrastructure (NSStatusItem)
   - Added NSStatusItem with cat emoji (🐱) in menu bar
@@ -109,7 +116,7 @@ Cat Shield is a macOS utility that creates a semi-transparent overlay to block k
 | Status | Count | Issues |
 |--------|-------|--------|
 | Open | 6 | #10, #11, #13, #16, #18, #19 |
-| Closed | 7 | #3, #5, #6, #7, #14, #15, #17 |
+| Closed | 8 | #3, #5, #6, #7, #14, #15, #17, #25 |
 
 ### By Priority
 - 🔴 Critical: 0
@@ -117,6 +124,7 @@ Cat Shield is a macOS utility that creates a semi-transparent overlay to block k
 - 🟢 Medium: 2 (#10, #16)
 - 🔵 Low: 2 (#11, #19)
 - Epic: 1 (#13)
+- Configuration: 1 (#25 - Closed)
 
 ## Recommended Implementation Order
 
@@ -157,6 +165,11 @@ Potential future enhancements (not yet tracked as issues):
 ## Changelog
 
 ### 2026-01-06
+- Completed Issue #25: Limit Claude GitHub Action to only respond to comments
+  - Removed `pull_request`, `issues`, `pull_request_review`, `pull_request_review_comment` triggers
+  - Kept only `issue_comment` trigger (covers both issue and PR comments)
+  - Added `if: contains(github.event.comment.body, '@claude')` condition
+  - Reduces noise from automatic triggers; Claude now only responds when explicitly mentioned
 - Completed Issue #17: Refactor Overlay to On-Demand Activation
   - `catshield` (no args) now shows menu bar icon only, no overlay
   - CLI args (--timer, --exit-key) start protection immediately (preserves scripting)


### PR DESCRIPTION
## Summary

- Removes automatic triggers for PR and issue events (pull_request, issues, pull_request_review, pull_request_review_comment)
- Keeps only the `issue_comment` trigger which fires on both issue and PR comments
- Adds `if: contains(github.event.comment.body, '@claude')` condition so Claude only responds when explicitly mentioned

Closes #25

## Test Plan

- [ ] Verify new issues no longer trigger Claude automatically
- [ ] Verify new/updated PRs no longer trigger Claude automatically
- [ ] Verify commenting on an issue/PR WITHOUT mentioning @claude does not trigger Claude
- [ ] Verify commenting on an issue/PR WITH @claude mention triggers Claude to respond

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Action configuration to respond only when explicitly mentioned in issue comments, reducing notification noise.

* **Documentation**
  * Updated roadmap to reflect configuration improvements and simplified triggering behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->