### PR TITLE
fix: menu items now visually disabled when windows are open (#38)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -183,21 +183,21 @@ Cat Shield is a macOS utility that creates a semi-transparent overlay to block k
 
 | Issue | Title | Completed |
 |-------|-------|-----------|
+| #38 | Menu items not visually disabled when windows are open | 2026-01-08 |
 | #30 | Add real-time validation for Exit Key field in Settings Window | 2026-01-08 |
 
 ## Issue Summary
 
 | Status | Count | Issues |
 |--------|-------|--------|
-| Open | 3 | #11, #13, #28 |
-| Closed | 16 | #3, #5, #6, #7, #10, #14, #15, #16, #17, #18, #19, #24, #25, #30, #31, #35 |
+| Open | 2 | #11, #28 |
+| Closed | 18 | #3, #5, #6, #7, #10, #13, #14, #15, #16, #17, #18, #19, #24, #25, #30, #31, #35, #38 |
 
 ### By Priority
 - 🔴 Critical: 0
 - 🟡 High: 0
 - 🟢 Medium: 1 (#28)
 - 🔵 Low: 1 (#11)
-- Epic: 1 (#13)
 
 ## Recommended Implementation Order
 
@@ -246,6 +246,14 @@ Potential future enhancements (not yet tracked as issues):
 ## Changelog
 
 ### 2026-01-08
+- Completed Issue #38: Fix menu items not visually disabled when windows are open
+  - Settings and About menu items now appear visually grayed out when their windows are open
+  - Root cause: NSMenu's `autoenablesItems` was overriding manual `setEnabled(false)` calls
+  - Fix: Added `menu.setAutoenablesItems(false)` in menu bar setup (`src/ui/menu_bar/setup.rs`)
+  - This allows the existing `setEnabled()` calls in settings/about window code to work correctly
+  - Menu items properly re-enable (visually and functionally) when windows are closed
+  - Updated issue counts: 2 open, 18 closed
+
 - Completed Issue #30: Add real-time validation for Exit Key field in Settings Window
   - Exit Key text field now validates input as the user types
   - Added `exitKeyChanged:` action method to `SettingsActionHandler`

--- a/src/ui/menu_bar/setup.rs
+++ b/src/ui/menu_bar/setup.rs
@@ -50,6 +50,10 @@ pub fn setup_menu_bar(mtm: MainThreadMarker) -> Retained<NSStatusItem> {
     // Create the main dropdown menu
     let menu = NSMenu::new(mtm);
 
+    // Disable auto-enabling of menu items so our manual setEnabled calls work
+    // This ensures Settings/About menu items appear visually grayed when their windows are open
+    menu.setAutoenablesItems(false);
+
     // ============================================
     // HEADER SECTION
     // ============================================


### PR DESCRIPTION
## Summary

- Fixed Settings and About menu items not appearing visually grayed out when their windows are open
- Root cause: NSMenu's `autoenablesItems` property (default: true) was overriding manual `setEnabled(false)` calls
- Fix: Added `menu.setAutoenablesItems(false)` in menu bar setup to allow manual state control

## Test plan

- [ ] Launch Cat Shield in menu bar mode
- [ ] Click "Settings..." menu item to open Settings window
- [ ] Click menu bar icon again and verify "Settings..." is grayed out
- [ ] Close Settings window and verify "Settings..." is no longer grayed out
- [ ] Repeat for "About Cat Shield" menu item
- [ ] Verify all other menu items still function correctly (Start Protection, Quit, etc.)

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved issue where menu items failed to display as visually disabled when windows are open, improving UI consistency and user experience.

* **Documentation**
  * Roadmap updated with newly completed items, changelog entries for current sprint, and revised issue status tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->