### PR TITLE
fix: remove initial Exit Key validation on Settings window open (Issue #48)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -195,6 +195,11 @@ Cat Shield is a macOS utility that creates a semi-transparent overlay to block k
   - Reset does NOT auto-save - user must click Save to persist changes
   - Increased window height from 340 to 370 pixels for better visual spacing
   - Provides easy way to restore factory settings without manually editing each field
+- [x] **Issue #48**: Exit Key validation should not show on initial Settings window open
+  - Removed `validate_exit_key_realtime()` call that ran on window open
+  - Validation label now starts empty when Settings window opens
+  - Validation only appears after user modifies the Exit Key field
+  - Real-time validation still works via `controlTextDidChange:` delegate method
 
 ### Other Open Issues
 
@@ -206,6 +211,7 @@ Cat Shield is a macOS utility that creates a semi-transparent overlay to block k
 
 | Issue | Title | Completed |
 |-------|-------|-----------|
+| #48 | Exit Key validation should not show on initial Settings window open | 2026-01-09 |
 | #46 | Add 'Reset to Default' button and improve spacing in Settings window | 2026-01-09 |
 | #44 | Refactoring - Improve code safety, reduce duplication, consolidate state | 2026-01-09 |
 | #42 | Enable Help menu links (Documentation & Report Issue) | 2026-01-09 |
@@ -218,7 +224,7 @@ Cat Shield is a macOS utility that creates a semi-transparent overlay to block k
 | Status | Count | Issues |
 |--------|-------|--------|
 | Open | 1 | #28 |
-| Closed | 22 | #3, #5, #6, #7, #10, #11, #13, #14, #15, #16, #17, #18, #19, #24, #25, #30, #31, #35, #38, #42, #44, #46 |
+| Closed | 23 | #3, #5, #6, #7, #10, #11, #13, #14, #15, #16, #17, #18, #19, #24, #25, #30, #31, #35, #38, #42, #44, #46, #48 |
 
 ### By Priority
 - 🔴 Critical: 0
@@ -273,6 +279,13 @@ Potential future enhancements (not yet tracked as issues):
 ## Changelog
 
 ### 2026-01-09
+- Completed Issue #48: Exit Key validation should not show on initial Settings window open
+  - Removed the `validate_exit_key_realtime()` call that ran immediately when Settings window opens
+  - Validation label now starts empty (no "✓ Valid" message on open)
+  - Validation only appears after user modifies the Exit Key field
+  - The `controlTextDidChange:` delegate method still handles real-time validation on edits
+  - Updated issue counts: 1 open, 23 closed
+
 - Completed Issue #46: Add 'Reset to Default' button and improve spacing in Settings window
   - Added "Reset to Default" button on the left side of the button row
   - Button resets all settings fields to their default values:

--- a/src/ui/windows/settings.rs
+++ b/src/ui/windows/settings.rs
@@ -718,8 +718,9 @@ pub fn show_settings_window(mtm: MainThreadMarker) {
         );
         std::mem::forget(exit_key_validation);
 
-        // Show initial validation state for the pre-filled exit key value
-        validate_exit_key_realtime(config.exit_key.as_deref().unwrap_or(DEFAULT_EXIT_KEY));
+        // Note: Do NOT call validate_exit_key_realtime() here.
+        // Validation should only appear after user modifies the field.
+        // The delegate's controlTextDidChange: handles real-time validation on edits.
 
         // ========================================
         // Default Timer Section


### PR DESCRIPTION
## Summary

- Remove the initial `validate_exit_key_realtime()` call that ran when the Settings window opened
- Validation label now starts empty instead of showing "✓ Valid" immediately
- Validation only appears after user modifies the Exit Key field
- Real-time validation still works via the `controlTextDidChange:` delegate method

Closes #48

## Test plan

- [ ] Open Settings window from menu bar → Exit Key validation label should be **empty** (no "✓ Valid")
- [ ] Type in Exit Key field → validation should appear ("✓ Valid" for valid, error for invalid)
- [ ] Clear Exit Key field → should show "Using default: Cmd+Q"
- [ ] Click Save → validation still works correctly on save
- [ ] Click Reset to Default → validation should show for the reset value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Exit Key validation displaying on initial Settings window open. The validation label now starts empty and only appears when the user modifies the Exit Key field, reducing unnecessary visual clutter.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->