### PR TITLE
fix: address memory leaks in NSTextField label cleanup (PR #70 feedback)

### DIFF
--- a/src/ui/shield.rs
+++ b/src/ui/shield.rs
@@ -13,7 +13,7 @@ use crate::ui::ptr_helper::with_ptr_void;
 use crate::ui::state::{menu_bar, shield, IS_MOUSE_INSIDE, MOUSE_DOWN_TIME};
 use crate::ui::views::{CloseButtonLabelView, CloseButtonView};
 use objc2::rc::Retained;
-use objc2_app_kit::{NSMenuItem, NSScreen, NSWindow};
+use objc2_app_kit::{NSMenuItem, NSScreen, NSTextField, NSWindow};
 use objc2_core_foundation::{kCFRunLoopCommonModes, CFString};
 use objc2_foundation::MainThreadMarker;
 use std::ffi::c_void;
@@ -239,11 +239,64 @@ pub fn deactivate_shield() {
     // Clear timer display view reference (only set in immediate mode, but clear for safety)
     shield::TIMER_VIEW.store(std::ptr::null_mut(), Ordering::Release);
 
-    // Clear NSTextField label references
-    shield::TIMER_HEADER.store(std::ptr::null_mut(), Ordering::Release);
-    shield::TIMER_TIME.store(std::ptr::null_mut(), Ordering::Release);
-    shield::TIMER_WARNING.store(std::ptr::null_mut(), Ordering::Release);
-    shield::CLOSE_BUTTON_TEXT.store(std::ptr::null_mut(), Ordering::Release);
+    // Release NSTextField label references properly to avoid memory leaks
+    // Each label was created with Retained and forgotten, so we must reclaim ownership
+    let timer_header_ptr = shield::TIMER_HEADER.swap(std::ptr::null_mut(), Ordering::AcqRel);
+    if !timer_header_ptr.is_null() {
+        // SAFETY: Retained::from_raw is safe because:
+        // - timer_header_ptr was stored from a valid Retained<NSTextField> in timer_display.rs
+        // - The atomic swap ensures we only reclaim ownership once
+        // - The pointer type cast is correct (it was stored as *mut c_void from NSTextField)
+        unsafe {
+            let _label: Retained<NSTextField> =
+                Retained::from_raw(timer_header_ptr as *mut NSTextField)
+                    .expect("shield::TIMER_HEADER was valid");
+            // Dropped here, calling release()
+        }
+    }
+
+    let timer_time_ptr = shield::TIMER_TIME.swap(std::ptr::null_mut(), Ordering::AcqRel);
+    if !timer_time_ptr.is_null() {
+        // SAFETY: Retained::from_raw is safe because:
+        // - timer_time_ptr was stored from a valid Retained<NSTextField> in timer_display.rs
+        // - The atomic swap ensures we only reclaim ownership once
+        // - The pointer type cast is correct (it was stored as *mut c_void from NSTextField)
+        unsafe {
+            let _label: Retained<NSTextField> =
+                Retained::from_raw(timer_time_ptr as *mut NSTextField)
+                    .expect("shield::TIMER_TIME was valid");
+            // Dropped here, calling release()
+        }
+    }
+
+    let timer_warning_ptr = shield::TIMER_WARNING.swap(std::ptr::null_mut(), Ordering::AcqRel);
+    if !timer_warning_ptr.is_null() {
+        // SAFETY: Retained::from_raw is safe because:
+        // - timer_warning_ptr was stored from a valid Retained<NSTextField> in timer_display.rs
+        // - The atomic swap ensures we only reclaim ownership once
+        // - The pointer type cast is correct (it was stored as *mut c_void from NSTextField)
+        unsafe {
+            let _label: Retained<NSTextField> =
+                Retained::from_raw(timer_warning_ptr as *mut NSTextField)
+                    .expect("shield::TIMER_WARNING was valid");
+            // Dropped here, calling release()
+        }
+    }
+
+    let close_button_text_ptr =
+        shield::CLOSE_BUTTON_TEXT.swap(std::ptr::null_mut(), Ordering::AcqRel);
+    if !close_button_text_ptr.is_null() {
+        // SAFETY: Retained::from_raw is safe because:
+        // - close_button_text_ptr was stored from a valid Retained<NSTextField> in close_button_label.rs
+        // - The atomic swap ensures we only reclaim ownership once
+        // - The pointer type cast is correct (it was stored as *mut c_void from NSTextField)
+        unsafe {
+            let _label: Retained<NSTextField> =
+                Retained::from_raw(close_button_text_ptr as *mut NSTextField)
+                    .expect("shield::CLOSE_BUTTON_TEXT was valid");
+            // Dropped here, calling release()
+        }
+    }
 
     // Reset auto-exit timer state
     AUTO_EXIT_ENABLED.store(false, Ordering::Release);

--- a/src/ui/windows/about.rs
+++ b/src/ui/windows/about.rs
@@ -405,8 +405,10 @@ pub fn show_about_window(mtm: MainThreadMarker) {
     // - The pointer was already stored in about::WINDOW earlier in this function
     // - The window must remain valid while displayed
     // - The Objective-C runtime also holds references
-    // Cleanup: The window is properly closed and released via
-    // cleanup_about_window_references() when the window closes.
+    // Cleanup: The panel intentionally lives for the app's lifetime and is reused
+    // across multiple open/close cycles. When the window closes, only the pointer
+    // is cleared (not released) so the panel can be reshown. The subviews are
+    // released by NSWindow when closed, but the panel itself persists.
     std::mem::forget(panel);
 
     println!("  About window opened");

--- a/src/ui/windows/settings.rs
+++ b/src/ui/windows/settings.rs
@@ -1368,8 +1368,10 @@ fn finalize_and_show_window(mtm: MainThreadMarker, panel: Retained<NSPanel>) {
     // - The pointer was already stored in settings::WINDOW (in show_settings_window)
     // - The window must remain valid while displayed
     // - The Objective-C runtime also holds references
-    // Cleanup: The window is properly closed and released via
-    // cleanup_settings_window_references() when the window closes.
+    // Cleanup: The panel intentionally lives for the app's lifetime and is reused
+    // across multiple open/close cycles. When the window closes, only the pointer
+    // is cleared (not released) so the panel can be reshown. The subviews are
+    // released by NSWindow when closed, but the panel itself persists.
     std::mem::forget(panel);
 
     println!("  Settings window opened");


### PR DESCRIPTION
## Summary

This PR addresses the CodeRabbit feedback from PR #70, fixing memory leaks and correcting inaccurate SAFETY comments.

## Changes

### 🔴 Critical Fix: NSTextField Label Memory Leaks

CodeRabbit correctly identified that the following global pointers were only being set to null in `deactivate_shield()` without reclaiming ownership:

- `shield::TIMER_HEADER`
- `shield::TIMER_TIME`  
- `shield::TIMER_WARNING`
- `shield::CLOSE_BUTTON_TEXT`

Each label was created with `Retained<NSTextField>` and forgotten via `std::mem::forget()`, which incremented the reference count. Without reclaiming ownership via `Retained::from_raw()`, the reference count remained unbalanced, causing memory leaks on every shield activation/deactivation cycle.

**Fix:** Apply the same pattern used for `WINDOW`, `CLOSE_BUTTON`, and `CLOSE_BUTTON_LABEL`:
```rust
let timer_header_ptr = shield::TIMER_HEADER.swap(std::ptr::null_mut(), Ordering::AcqRel);
if !timer_header_ptr.is_null() {
    unsafe {
        let _label: Retained<NSTextField> =
            Retained::from_raw(timer_header_ptr as *mut NSTextField)
                .expect("shield::TIMER_HEADER was valid");
        // Dropped here, calling release()
    }
}
```

### 🟠 Documentation Fix: Panel Lifetime Comments

Updated SAFETY comments for settings and about window panels to accurately describe their lifecycle:

**Before (inaccurate):**
> Cleanup: The window is properly closed and released via cleanup_settings_window_references() when the window closes.

**After (accurate):**
> Cleanup: The panel intentionally lives for the app's lifetime and is reused across multiple open/close cycles. When the window closes, only the pointer is cleared (not released) so the panel can be reshown. The subviews are released by NSWindow when closed, but the panel itself persists.

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy -- -D warnings` passes (0 warnings)
- [x] All 110 tests pass
- [x] Memory leak pattern fixed to match existing working code

## Related

- Addresses feedback from: #70
- Original issue: #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)