### PR TITLE
fix: Dispatch action feedback clear to main thread (Issue #91)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "dirs",
+ "dispatch2",
  "objc2",
  "objc2-app-kit",
  "objc2-core-foundation",
@@ -164,6 +165,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
  "bitflags",
+ "block2",
+ "libc",
  "objc2",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ objc2-foundation = { version = "0.3", features = ["NSNotification", "NSString", 
 objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSBezierPath", "NSButton", "NSColor", "NSControl", "NSEvent", "NSFont", "NSGraphicsContext", "NSMenu", "NSMenuItem", "NSPanel", "NSScreen", "NSSlider", "NSStatusBar", "NSStatusItem", "NSStringDrawing", "NSTableColumn", "NSTableView", "NSText", "NSTextField", "NSView", "NSWindow", "NSWorkspace"] }
 objc2-core-foundation = { version = "0.3", features = ["CFMachPort", "CFRunLoop", "CFString"] }
 objc2-core-graphics = { version = "0.3", features = ["CGEvent", "CGEventTypes", "CGRemoteOperation"] }
+dispatch2 = "0.3"
 
 [dev-dependencies]
 tempfile = "3.10"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -296,20 +296,23 @@ Testing (can be done in parallel):
 | Priority | Issue | Title | Dependencies | Effort |
 |----------|-------|-------|--------------|--------|
 | ~~🔴 Critical~~ | ~~#87~~ | ~~Settings menu item stays disabled after closing Settings window~~ | ~~None~~ | ~~✅ Complete~~ |
+| ~~🔴 High~~ | ~~#91~~ | ~~Action feedback clear called from background thread violates AppKit threading~~ | ~~None~~ | ~~✅ Complete~~ |
 | ~~🟢 Medium~~ | ~~#86~~ | ~~Show real-time validation error when entering duplicate allowed key~~ | ~~None~~ | ~~✅ Complete~~ |
 | 🔵 Low | #85 | Add Undo button to Settings window for reverting individual changes | None | ~1-2 days |
 
 **Implementation Order (priority-based, all independent):**
 ```text
 1. #87: Fix Settings menu item ✅ COMPLETE
-2. #86: Duplicate key validation ✅ COMPLETE
-3. #85: Undo button (Low priority)
+2. #91: Fix AppKit threading violation ✅ COMPLETE
+3. #86: Duplicate key validation ✅ COMPLETE
+4. #85: Undo button (Low priority)
 ```
 
 ### Recently Completed
 
 | Issue | Title | Completed |
 |-------|-------|-----------|
+| #91 | fix: Action feedback clear called from background thread violates AppKit threading | 2026-01-12 |
 | #86 | feat: Show real-time validation error when entering duplicate allowed key | 2026-01-12 |
 | #87 | fix: Settings menu item stays disabled after closing Settings window | 2026-01-12 |
 | #83 | feat: Add ability to select and remove individual allowed keys in Settings | 2026-01-11 |
@@ -341,7 +344,7 @@ Testing (can be done in parallel):
 | Status | Count | Issues |
 |--------|-------|--------|
 | Open | 1 | #85 |
-| Closed | 42 | #3, #5, #6, #7, #10, #11, #13, #14, #15, #16, #17, #18, #19, #24, #25, #28, #30, #31, #35, #38, #42, #44, #46, #48, #49, #52, #53, #54, #55, #56, #57, #58, #59, #60, #64, #65, #73, #75, #80, #83, #86, #87 |
+| Closed | 43 | #3, #5, #6, #7, #10, #11, #13, #14, #15, #16, #17, #18, #19, #24, #25, #28, #30, #31, #35, #38, #42, #44, #46, #48, #49, #52, #53, #54, #55, #56, #57, #58, #59, #60, #64, #65, #73, #75, #80, #83, #86, #87, #91 |
 
 ### By Priority
 - 🔴 Critical: 0
@@ -419,7 +422,7 @@ Phase 6 (COMPLETE):
 Input Control:  #64 (Key Allowlist) ✅ ─── #65 (Preset Groups) ✅
 
 Phase 7 (CURRENT):
-Settings Polish: #87 (Menu Bug) ✅ ─── #86 (Duplicate Validation) ✅ ─── #85 (Undo Button) 🔵
+Settings Polish: #87 (Menu Bug) ✅ ─── #91 (Threading Fix) ✅ ─── #86 (Duplicate Validation) ✅ ─── #85 (Undo Button) 🔵
 ```
 
 ## Future Considerations
@@ -435,6 +438,14 @@ Potential future enhancements (not yet tracked as issues):
 ## Changelog
 
 ### 2026-01-12
+- Completed Issue #91: Fix action feedback clear called from background thread (AppKit threading violation)
+  - Root cause: `clear_action_feedback()` was called directly from a background thread spawned by `show_action_feedback()`
+  - AppKit requires all UI operations to happen on the main thread
+  - Fix: Added `dispatch2` crate dependency and wrapped the `clear_action_feedback()` call in `dispatch2::run_on_main()`
+  - The closure is now dispatched to the main queue, ensuring thread-safe UI updates
+  - Prevents undefined behavior, crashes, and UI glitches like the Settings menu item staying disabled
+  - Updated issue counts: 1 open, 43 closed
+
 - Completed Issue #86: Show real-time validation error when entering duplicate allowed key
   - Modified `validate_add_key_realtime()` in `src/ui/windows/settings.rs` to check for duplicates
   - When a valid key is entered, checks against pending allowed keys list (case-insensitive)

--- a/src/ui/windows/settings.rs
+++ b/src/ui/windows/settings.rs
@@ -2102,7 +2102,10 @@ fn show_action_feedback(message: &str) {
 
         // Only clear if no newer feedback has been shown
         if FEEDBACK_COUNTER.load(Ordering::SeqCst) == current_count {
-            clear_action_feedback();
+            // Dispatch to main thread for UI update (AppKit requirement)
+            dispatch2::run_on_main(|_mtm| {
+                clear_action_feedback();
+            });
         }
     });
 }


### PR DESCRIPTION
## Summary
- Fixes AppKit threading violation where `clear_action_feedback()` was called from a background thread
- Added `dispatch2` crate to dispatch UI updates to the main queue
- Wrapped `clear_action_feedback()` call in `dispatch2::run_on_main()` to ensure thread-safe UI operations

## Root Cause
In `show_action_feedback()`, a background thread was spawned to clear the feedback label after 3 seconds. The `clear_action_feedback()` function modifies an `NSTextField`, which violates AppKit's requirement that all UI operations happen on the main thread.

## Fix
Use `dispatch2::run_on_main()` to dispatch the UI clear operation to the main queue, ensuring the `NSTextField` modification happens on the main thread.

## Test plan
- [x] Build succeeds with `cargo build --release`
- [x] All 217 tests pass with `cargo test`
- [ ] Manual testing: Open Settings, click a preset button, close before 3 seconds - Settings menu item should remain enabled

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved threading violation affecting action feedback display, improving UI stability and responsiveness.

* **Documentation**
  * Updated project roadmap to reflect completion of threading-related improvements in the current development phase.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->