### PR TITLE
Add shell startup snippet to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,24 @@ sudo chmod +x /usr/local/bin/catshield
 ./uninstall.sh
 ```
 
+### Auto-Start on Shell Startup
+
+Add the following snippet to your shell configuration file (`~/.bashrc`, `~/.zshrc`, etc.) to launch Cat Shield automatically whenever you open a new terminal. If an instance is already running, it will be skipped.
+
+```bash
+# Start Cat Shield in the background (if not already running)
+if command -v catshield &>/dev/null && ! pgrep -x catshield &>/dev/null; then
+  catshield &>/dev/null &
+  disown
+fi
+```
+
+After adding the snippet, restart your shell or source the config file:
+
+```bash
+source ~/.bashrc   # or ~/.zshrc
+```
+
 ## Usage
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -69,16 +69,22 @@ Add the following snippet to your shell configuration file (`~/.bashrc`, `~/.zsh
 
 ```bash
 # Start Cat Shield in the background (if not already running)
-if command -v catshield &>/dev/null && ! pgrep -x catshield &>/dev/null; then
-  catshield &>/dev/null &
-  disown
+# Only launch in graphical sessions — skip for SSH/headless environments
+if [ -n "$DISPLAY" ] || [ -n "$WAYLAND_DISPLAY" ]; then
+  if [ -z "$SSH_TTY" ] && [ -z "$SSH_CONNECTION" ]; then
+    if command -v catshield &>/dev/null && ! pgrep -x catshield &>/dev/null; then
+      catshield &>/dev/null &
+      disown
+    fi
+  fi
 fi
 ```
 
 After adding the snippet, restart your shell or source the config file:
 
 ```bash
-source ~/.bashrc   # or ~/.zshrc
+source ~/.bashrc   # for Bash
+source ~/.zshrc    # for Zsh
 ```
 
 ## Usage


### PR DESCRIPTION
Adds a section showing how to auto-start catshield on shell startup
by adding a snippet to .bashrc/.zshrc. The snippet checks if catshield
is installed and not already running before launching it in the background.

https://claude.ai/code/session_01GSJ4Jn8ciWRhcLNpS1NPfb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance to configure Cat Shield to auto-start in the background when opening a shell, including safeguards to skip SSH/headless sessions, prevent duplicate launches, and steps to reload your shell configuration after editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->